### PR TITLE
Bug fix: Remove KeepAlive from ssh config

### DIFF
--- a/config/ssh_config_v4
+++ b/config/ssh_config_v4
@@ -19,7 +19,6 @@ Host cmslpc*.fnal.gov cmslpc-sl7.fnal.gov cmslpc-el8.fnal.gov cmslpc-el9.fnal.go
     ServerAliveInterval 60
     ServerAliveCountMax 10
     TCPKeepAlive yes
-    KeepAlive yes
     StrictHostKeyChecking no
     UserKnownHostsFile /dev/null
 
@@ -92,7 +91,6 @@ Host *
     ServerAliveInterval 60
     ServerAliveCountMax 10
     TCPKeepAlive yes
-    KeepAlive yes
     PubkeyAcceptedKeyTypes=+ssh-dss
     AddKeysToAgent yes
     IdentityFile ~/.ssh/id_ed25519


### PR DESCRIPTION
Remove KeepAlive from ssh config as this is not a valid parameter.
See ssh config documentation [here](https://man.openbsd.org/ssh_config.5).

Fixed graphics forwarding for cmslpc (for example, ROOT TBrowser).
See issue [here](https://github.com/caleb-james-smith/Utility/issues/8).
